### PR TITLE
Fix unnecessary token refresh on search page

### DIFF
--- a/multimusicplatform/package-lock.json
+++ b/multimusicplatform/package-lock.json
@@ -1000,7 +1000,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1061,7 +1060,6 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1599,7 +1597,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2030,7 +2027,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2669,7 +2665,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4169,7 +4164,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4937,7 +4931,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5139,7 +5132,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5152,7 +5144,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6132,7 +6123,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6301,7 +6291,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/multimusicplatform/src/app/search/page.tsx
+++ b/multimusicplatform/src/app/search/page.tsx
@@ -23,6 +23,50 @@ interface Track {
   duration_ms: number;  // 👈 ADD THIS (needed for progress bar)
   preview_url: string | null;
 }
+
+interface StoredToken {
+  accessToken: string;
+  expiresAt: number; // Unix timestamp in milliseconds
+}
+
+// Helper functions for token management
+const getStoredToken = (platform: string): string | null => {
+  if (typeof window === 'undefined') return null;
+
+  const stored = localStorage.getItem(`${platform}_token`);
+  if (!stored) return null;
+
+  try {
+    const tokenData: StoredToken = JSON.parse(stored);
+    const now = Date.now();
+
+    // Check if token is expired (with 5-minute buffer for safety)
+    if (tokenData.expiresAt <= now) {
+      localStorage.removeItem(`${platform}_token`);
+      return null;
+    }
+
+    return tokenData.accessToken;
+  } catch {
+    localStorage.removeItem(`${platform}_token`);
+    return null;
+  }
+};
+
+const storeToken = (platform: string, accessToken: string, expiresIn: number): void => {
+  if (typeof window === 'undefined') return;
+
+  // Convert expiresIn (seconds) to expiration timestamp (milliseconds)
+  // Subtract 5 minutes (300 seconds) as a safety buffer
+  const expiresAt = Date.now() + ((expiresIn - 300) * 1000);
+
+  const tokenData: StoredToken = {
+    accessToken,
+    expiresAt,
+  };
+
+  localStorage.setItem(`${platform}_token`, JSON.stringify(tokenData));
+};
 export default function SearchPage() {
   const router = useRouter();
   const { isLoading: authLoading, isAuthenticated } = useAuth();
@@ -45,37 +89,66 @@ export default function SearchPage() {
     }
 
     if (isAuthenticated) {
+      // First, try to load tokens from localStorage
+      const spotifyStored = getStoredToken('spotify');
+      const soundcloudStored = getStoredToken('soundcloud');
+      const youtubeStored = getStoredToken('youtube');
+
+      if (spotifyStored) setSpotifyToken(spotifyStored);
+      if (soundcloudStored) setSoundcloudToken(soundcloudStored);
+      if (youtubeStored) setYoutubeToken(youtubeStored);
+
+      // Then refresh only if tokens are missing or expired
       loadPlatformTokens();
     }
   }, [authLoading, isAuthenticated, router]);
 
   const loadPlatformTokens = async () => {
-    // Load tokens for all platforms (silently fail if not connected)
-    try {
-      const spotifyResponse = await apiClient.spotifyRefresh();
-      if (spotifyResponse.data?.accessToken) {
-        setSpotifyToken(spotifyResponse.data.accessToken);
+    // Load tokens for all platforms (only refresh if expired or missing)
+
+    // Spotify
+    const spotifyStored = getStoredToken('spotify');
+    if (!spotifyStored) {
+      try {
+        console.log('Refreshing Spotify token...');
+        const spotifyResponse = await apiClient.spotifyRefresh();
+        if (spotifyResponse.data?.accessToken && spotifyResponse.data?.expiresIn) {
+          setSpotifyToken(spotifyResponse.data.accessToken);
+          storeToken('spotify', spotifyResponse.data.accessToken, spotifyResponse.data.expiresIn);
+        }
+      } catch (error) {
+        console.log('Spotify not connected');
       }
-    } catch (error) {
-      console.log('Spotify not connected');
     }
 
-    try {
-      const soundcloudResponse = await apiClient.soundcloudRefresh();
-      if (soundcloudResponse.data?.accessToken) {
-        setSoundcloudToken(soundcloudResponse.data.accessToken);
+    // SoundCloud
+    const soundcloudStored = getStoredToken('soundcloud');
+    if (!soundcloudStored) {
+      try {
+        console.log('Refreshing SoundCloud token...');
+        const soundcloudResponse = await apiClient.soundcloudRefresh();
+        if (soundcloudResponse.data?.accessToken && soundcloudResponse.data?.expiresIn) {
+          setSoundcloudToken(soundcloudResponse.data.accessToken);
+          storeToken('soundcloud', soundcloudResponse.data.accessToken, soundcloudResponse.data.expiresIn);
+        }
+      } catch (error) {
+        console.log('SoundCloud not connected');
       }
-    } catch (error) {
-      console.log('SoundCloud not connected');
     }
 
-    try {
-      const youtubeResponse = await apiClient.youtubeRefresh();
-      if (youtubeResponse.data?.accessToken) {
-        setYoutubeToken(youtubeResponse.data.accessToken);
+    // YouTube
+    const youtubeStored = getStoredToken('youtube');
+    if (!youtubeStored) {
+      try {
+        console.log('Refreshing YouTube token...');
+        const youtubeResponse = await apiClient.youtubeRefresh();
+        if (youtubeResponse.data?.accessToken && youtubeResponse.data?.expiresIn) {
+          setYoutubeToken(youtubeResponse.data.accessToken);
+          storeToken('youtube', youtubeResponse.data.accessToken, youtubeResponse.data.expiresIn);
+        }
+      } catch (error) {
+        console.log('YouTube not connected');
       }
-    } catch (error) {
-      console.log('YouTube not connected');
     }
   };
 


### PR DESCRIPTION
Added token expiration tracking to avoid refreshing platform tokens (Spotify, YouTube, SoundCloud) on every /search page load. Tokens are now:
- Stored in localStorage with expiration timestamps
- Only refreshed when expired or missing
- Checked with a 5-minute safety buffer

This improves performance by reducing unnecessary API calls when tokens are still valid.